### PR TITLE
fix: execute template in expandAlias for -a flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ build-darwin-aarch64: vendor
 	done
 
 test: vendor
-	$(GO) test -short -v $(TEST_FLAGS) ./pkg/* ./cmd/*
+	$(GO) test -short -v $(TEST_FLAGS) ./pkg/* ./cmd/* ./internal/mode/
 	if grep -Irn TODO: ./cmd/ ./pkg/;  then exit 1; fi
 
 # test with filter

--- a/internal/mode/query.go
+++ b/internal/mode/query.go
@@ -124,7 +124,7 @@ func Query(ctx context.Context, address *url.URL, query, warning, critical, alia
 }
 
 func expandAlias(alias string, labels model.Metric, value float64) string {
-	_, err := template.New("Output").Parse(alias)
+	tmpl, err := template.New("Output").Parse(alias)
 	var output string
 	if err != nil {
 		output = alias
@@ -137,7 +137,11 @@ func expandAlias(alias string, labels model.Metric, value float64) string {
 		}
 		labelMap["xvalue"] = fmt.Sprintf("%v", value)
 		var rendered bytes.Buffer
-		output = rendered.String()
+		if err := tmpl.Execute(&rendered, labelMap); err != nil {
+			output = alias
+		} else {
+			output = rendered.String()
+		}
 	}
 
 	return output

--- a/internal/mode/query_test.go
+++ b/internal/mode/query_test.go
@@ -1,0 +1,77 @@
+package mode
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+)
+
+func TestExpandAlias(t *testing.T) {
+	tests := []struct {
+		name     string
+		alias    string
+		labels   model.Metric
+		value    float64
+		expected string
+	}{
+		{
+			name:     "simple template with label",
+			alias:    "Hostname: {{.hostname}}",
+			labels:   model.Metric{"hostname": "server01"},
+			value:    42.0,
+			expected: "Hostname: server01",
+		},
+		{
+			name:     "template with multiple labels",
+			alias:    "Host: {{.hostname}} Job: {{.job}}",
+			labels:   model.Metric{"hostname": "server01", "job": "prometheus"},
+			value:    1.0,
+			expected: "Host: server01 Job: prometheus",
+		},
+		{
+			name:     "template with xvalue",
+			alias:    "Value: {{.xvalue}}",
+			labels:   model.Metric{"hostname": "server01"},
+			value:    123.45,
+			expected: "Value: 123.45",
+		},
+		{
+			name:     "template with if-else condition",
+			alias:    "Status: {{if eq .xvalue \"1\"}}UP{{else}}DOWN{{end}}",
+			labels:   model.Metric{"hostname": "server01"},
+			value:    1.0,
+			expected: "Status: UP",
+		},
+		{
+			name:     "template with if-else condition false",
+			alias:    "Status: {{if eq .xvalue \"1\"}}UP{{else}}DOWN{{end}}",
+			labels:   model.Metric{"hostname": "server01"},
+			value:    0.0,
+			expected: "Status: DOWN",
+		},
+		{
+			name:     "invalid template fallback",
+			alias:    "{{invalid template",
+			labels:   model.Metric{"hostname": "server01"},
+			value:    42.0,
+			expected: "{{invalid template",
+		},
+		{
+			name:     "empty alias",
+			alias:    "",
+			labels:   model.Metric{"hostname": "server01"},
+			value:    42.0,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := expandAlias(tt.alias, tt.labels, tt.value)
+			if result != tt.expected {
+				t.Errorf("expandAlias(%q, ...) = %q, want %q", tt.alias, result, tt.expected)
+			}
+		})
+	}
+}
+

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -70,7 +70,7 @@ func Check(args []string) (check_x.State, string, *check_x.PerformanceDataCollec
 	cmd := &cli.Command{
 		Name:    "check_prometheus",
 		Usage:   "Checks different prometheus stats as well the data itself",
-		Version: "0.0.5",
+		Version: "0.0.6",
 		Flags: []cli.Flag{
 			&cli.Int64Flag{
 				Name:        "timeout",


### PR DESCRIPTION
The expandAlias function was parsing the template but never executing it, resulting in empty output when using the -a (alias) flag with template syntax. Now properly executes the template with the label map and handles execution errors by falling back to the original alias string.

Fixes alias templates like:
- check_prometheus m q -a 'Host: {{.hostname}}'
- check_prometheus m q -a 'Status: {{if eq .xvalue "1"}}UP{{else}}DOWN{{end}}'

Includes comprehensive unit tests covering:
- Simple label substitution
- Multiple labels
- xvalue special variable
- Conditional logic (if/else)
- Invalid template fallback